### PR TITLE
Added force_destroy attribute for s3 config data

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module "cloud_security" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.46.0 |
 
 ## Modules
 
@@ -104,6 +104,7 @@ module "cloud_security" {
 | <a name="input_enable_security_hub"></a> [enable\_security\_hub](#input\_enable\_security\_hub) | Whether to enable Security Hub | `bool` | `true` | no |
 | <a name="input_enabled_security_hub_standards"></a> [enabled\_security\_hub\_standards](#input\_enabled\_security\_hub\_standards) | A list of standards/rulesets to enable<br><br>See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_standards_subscription#argument-reference<br><br>The possible values are:<br><br>  - standards/aws-foundational-security-best-practices/v/1.0.0<br>  - ruleset/cis-aws-foundations-benchmark/v/1.2.0<br>  - standards/pci-dss/v/3.2.1 | `list(any)` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | n/a | yes |
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | `bool` | `false` | no |
 | <a name="input_guard_duty_s3_protection_enabled"></a> [guard\_duty\_s3\_protection\_enabled](#input\_guard\_duty\_s3\_protection\_enabled) | Flag to indicate whether S3 protection will be turned on in GuardDuty. | `bool` | `false` | no |
 | <a name="input_guard_duty_sns_subscribers"></a> [guard\_duty\_sns\_subscribers](#input\_guard\_duty\_sns\_subscribers) | A map of subscription configurations for SNS topics<br><br>For more information, see:<br>https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription#argument-reference<br><br>protocol:<br>  The protocol to use. The possible values for this are: sqs, sms, lambda, application. (http or https are partially<br>  supported, see link) (email is an option but is unsupported in terraform, see link).<br>endpoint:<br>  The endpoint to send data to, the contents will vary with the protocol. (see link for more information)<br>endpoint\_auto\_confirms:<br>  Boolean indicating whether the end point is capable of auto confirming subscription e.g., PagerDuty. Default is<br>  false<br>raw\_message\_delivery:<br>  Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property).<br>  Default is false | <pre>map(object({<br>    protocol               = string<br>    endpoint               = string<br>    endpoint_auto_confirms = bool<br>    raw_message_delivery   = bool<br>  }))</pre> | `null` | no |
 | <a name="input_inspector_account_list"></a> [inspector\_account\_list](#input\_inspector\_account\_list) | List of Account for which inspector has to be enabled | `list(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -54,8 +54,9 @@ module "aws_config_storage" {
   version = "1.0.0"
   enabled = var.enable_aws_config
 
-  name = local.name_prefix
-  tags = var.tags
+  name          = local.name_prefix
+  force_destroy = var.force_destroy
+  tags          = var.tags
 }
 
 module "config" {

--- a/variables.tf
+++ b/variables.tf
@@ -150,6 +150,11 @@ variable "enable_aws_config" {
   type        = bool
   default     = true
 }
+variable "force_destroy" {
+  type        = bool
+  description = "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable"
+  default     = false
+}
 
 variable "aws_config_sns_subscribers" {
   type = map(object({


### PR DESCRIPTION
## Description

Added force_destroy attribute for s3 config data

## Related Issue

- [GH-27](https://github.com/sourcefuse/terraform-aws-arc-security/issues/27)

## Checklist

Please ensure that the following steps are completed before submitting the pull request:

- [x] Code follows the Terraform best practices and style guidelines.
- [x] Changes are appropriately documented, including any necessary updates to README or other documentation files.
- [ ] Unit tests have been added or updated to cover the changes introduced by this pull request.
- [x] Changes have been tested locally and verified to work as expected.
- [ ] The code has been reviewed to ensure it aligns with the project's goals and standards.
- [ ] Dependencies and backward compatibility have been considered and addressed if applicable.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

